### PR TITLE
[MAINTENANCE]: Upgrading thor version to 0.18.1 for rails 4

### DIFF
--- a/lib/metaforce/version.rb
+++ b/lib/metaforce/version.rb
@@ -1,3 +1,3 @@
 module Metaforce
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/lib/metaforce/version.rb
+++ b/lib/metaforce/version.rb
@@ -1,3 +1,3 @@
 module Metaforce
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
 end

--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -25,7 +25,7 @@ EOL
   s.add_dependency 'zip-zip'
   s.add_dependency 'activesupport'
   s.add_dependency 'hashie', '~> 1.2.0'
-  s.add_dependency 'thor', '~> 0.16.0'
+  s.add_dependency 'thor', '~> 0.18.1'
   s.add_dependency 'listen', '~> 0.6.0'
   s.add_dependency 'rb-fsevent', '~> 0.9.1'
 


### PR DESCRIPTION
Active support 4 depends on thor 0.18.1 to run.
Upgrading metaforce to be compatible with the latest verion
of thor
